### PR TITLE
Add carrier tracking to web order completion

### DIFF
--- a/backend/prisma/migrations/20250917225738_add_order_carrier_fields/migration.sql
+++ b/backend/prisma/migrations/20250917225738_add_order_carrier_fields/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Orders" ADD COLUMN     "carrierId" TEXT,
+ADD COLUMN     "carrierMode" TEXT,
+ADD COLUMN     "carrierName" TEXT;
+

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -515,6 +515,9 @@ model Orders {
   city            String
   postalCode      String
   phone           String?
+  carrierId       String?
+  carrierName     String?
+  carrierMode     String?
   createdAt       DateTime    @default(now())
   updatedAt       DateTime    @updatedAt
 

--- a/backend/src/websales/dto/complete-order.dto.ts
+++ b/backend/src/websales/dto/complete-order.dto.ts
@@ -1,0 +1,64 @@
+import {
+  IsIn,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  ValidateIf,
+} from 'class-validator';
+
+const DELIVERY_ALIASES = ['DELIVERY', 'ENVIO A DOMICILIO'];
+
+function normalizeValue(value?: string | null) {
+  if (!value) return '';
+  return value
+    .toString()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim()
+    .toUpperCase();
+}
+
+function shouldRequireCarrier(dto: CompleteOrderDto) {
+  const normalized = normalizeValue(dto?.shippingMethod);
+  if (!normalized) return false;
+  return DELIVERY_ALIASES.some((alias) => alias === normalized);
+}
+
+export class CompleteOrderDto {
+  @IsOptional()
+  @IsString()
+  shippingMethod?: string;
+
+  @IsOptional()
+  @IsString()
+  carrierId?: string;
+
+  @ValidateIf(shouldRequireCarrier)
+  @IsString()
+  @IsNotEmpty()
+  carrierName?: string;
+
+  @ValidateIf(shouldRequireCarrier)
+  @IsString()
+  @IsNotEmpty()
+  @IsIn(['HOME_DELIVERY', 'DELIVERY', 'AGENCY_PICKUP', 'PICKUP'])
+  carrierMode?: string;
+}
+
+export const normalizeShippingMethod = normalizeValue;
+
+export function normalizeCarrierMode(value?: string | null) {
+  const normalized = normalizeValue(value);
+  if (['DELIVERY', 'HOME_DELIVERY'].includes(normalized)) {
+    return 'HOME_DELIVERY';
+  }
+  if (['PICKUP', 'AGENCY_PICKUP', 'AGENCY'].includes(normalized)) {
+    return 'AGENCY_PICKUP';
+  }
+  return normalized || undefined;
+}
+
+export function isDeliveryShipping(value?: string | null) {
+  const normalized = normalizeValue(value);
+  return DELIVERY_ALIASES.includes(normalized);
+}

--- a/backend/src/websales/websales.controller.ts
+++ b/backend/src/websales/websales.controller.ts
@@ -19,6 +19,7 @@ import { extname } from 'path';
 import { Request } from 'express';
 import { WebSalesService } from './websales.service';
 import { CreateWebSaleDto } from './dto/create-websale.dto';
+import { CompleteOrderDto } from './dto/complete-order.dto';
 import { JwtAuthGuard } from '../users/jwt-auth.guard';
 import { RolesGuard } from '../users/roles.guard';
 import { Roles } from '../users/roles.decorator';
@@ -49,9 +50,10 @@ export class WebSalesController {
   @Post('order/:id/complete')
   async completeOrder(
     @Param('id', ParseIntPipe) id: number,
+    @Body() dto: CompleteOrderDto,
     @Req() req: Request,
   ) {
-    return this.webSalesService.completeWebOrder(id, req);
+    return this.webSalesService.completeWebOrder(id, dto, req);
   }
 
   @Patch('order/:id/series')
@@ -60,11 +62,13 @@ export class WebSalesController {
     @Body('items') items: { productId: number; series: string[] }[],
   ) {
     if (!Array.isArray(items)) {
-      throw new BadRequestException('Formato inválido: items debe ser un arreglo');
+      throw new BadRequestException(
+        'Formato inválido: items debe ser un arreglo',
+      );
     }
     return this.webSalesService.updateOrderSeries(id, items);
   }
-  
+
   @Post('order/:id/reject')
   async rejectOrder(@Param('id', ParseIntPipe) id: number) {
     return this.webSalesService.rejectWebOrder(id);

--- a/fronted/src/app/dashboard/orders/column.tsx
+++ b/fronted/src/app/dashboard/orders/column.tsx
@@ -31,6 +31,10 @@ export type Order = {
   total: number;
   status: string;
   origin?: string;
+  shippingMethod?: string;
+  carrierName?: string;
+  carrierId?: string;
+  carrierMode?: string;
 };
 
 export function getColumns(
@@ -113,13 +117,40 @@ export function getColumns(
                   </AlertDialogHeader>
                   <AlertDialogFooter>
                     <AlertDialogCancel>Cancelar</AlertDialogCancel>
-                    <AlertDialogAction
-                      onClick={async () => {
-                        try {
-                          const createdSale = await completeWebOrder(row.original.id);
-                          toast.success("Orden completada");
-                          if (onStatusUpdate) {
-                            onStatusUpdate(row.original.id, "COMPLETED");
+              <AlertDialogAction
+                onClick={async () => {
+                  try {
+                        const shippingMethodValue = row.original.shippingMethod ?? '';
+                        const normalizedShipping = shippingMethodValue
+                          ? shippingMethodValue
+                              .normalize('NFD')
+                              .replace(/[\u0300-\u036f]/g, '')
+                              .trim()
+                              .toUpperCase()
+                          : '';
+                        const requiresCarrier =
+                          normalizedShipping === 'DELIVERY' ||
+                          normalizedShipping === 'ENVIO A DOMICILIO';
+
+                        if (
+                          requiresCarrier &&
+                          (!row.original.carrierName || !row.original.carrierMode)
+                        ) {
+                          toast.error(
+                            'Completa los datos de transporte desde el detalle de la orden antes de confirmar.',
+                          );
+                          return;
+                        }
+
+                        const createdSale = await completeWebOrder(row.original.id, {
+                          carrierId: row.original.carrierId,
+                          carrierName: row.original.carrierName,
+                          carrierMode: row.original.carrierMode,
+                          shippingMethod: row.original.shippingMethod,
+                        });
+                        toast.success("Orden completada");
+                        if (onStatusUpdate) {
+                          onStatusUpdate(row.original.id, "COMPLETED");
                           }
                           const invoice =
                             createdSale && Array.isArray(createdSale.invoices) && createdSale.invoices.length > 0

--- a/fronted/src/app/dashboard/orders/page.tsx
+++ b/fronted/src/app/dashboard/orders/page.tsx
@@ -66,6 +66,10 @@ export default function OrdersPage() {
             total: o.payload?.total ?? 0,
             status: o.status,
             origin,
+            shippingMethod: typeof o?.payload?.shippingMethod === 'string' ? o.payload.shippingMethod : undefined,
+            carrierName: o.carrierName ?? undefined,
+            carrierId: o.carrierId ?? undefined,
+            carrierMode: o.carrierMode ?? undefined,
           };
         });
         setOrders(mapped);

--- a/fronted/src/app/dashboard/sales/sales.api.tsx
+++ b/fronted/src/app/dashboard/sales/sales.api.tsx
@@ -100,9 +100,19 @@ export async function payWithCulqi(token: string, amount: number, order: any) {
   return res.json();
 }
 
-export async function completeWebOrder(id: number) {
+export async function completeWebOrder(
+  id: number,
+  data?: {
+    carrierId?: string;
+    carrierName?: string;
+    carrierMode?: string;
+    shippingMethod?: string;
+  },
+) {
   const response = await fetch(`${BACKEND_URL}/api/web-sales/order/${id}/complete`, {
     method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data ?? {}),
   });
   if (!response.ok) {
     const errorText = await response.text();

--- a/fronted/src/app/track-order/[id]/page.tsx
+++ b/fronted/src/app/track-order/[id]/page.tsx
@@ -136,6 +136,61 @@ export default function TrackOrderDetailsPage() {
 
   const subtotal = products.reduce((s, p) => s + p.subtotal, 0);
 
+  const orderPayload: any = order.payload || {};
+  const orderRecord: any = order || {};
+  const shippingMethodValue =
+    typeof orderPayload.shippingMethod === 'string' ? orderPayload.shippingMethod : '';
+  const normalizedShippingMethod = shippingMethodValue
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim()
+    .toUpperCase();
+  let shippingMethodLabel = shippingMethodValue || '-';
+  let estimatedDelivery = orderPayload.estimatedDelivery ?? '-';
+  if (normalizedShippingMethod === 'PICKUP' || normalizedShippingMethod === 'RECOJO EN TIENDA') {
+    shippingMethodLabel = 'RECOJO EN TIENDA';
+    estimatedDelivery = 'Inmediata';
+  } else if (
+    normalizedShippingMethod === 'DELIVERY' ||
+    normalizedShippingMethod === 'ENVIO A DOMICILIO'
+  ) {
+    shippingMethodLabel =
+      normalizedShippingMethod === 'DELIVERY' ? 'DELIVERY' : 'ENVIO A DOMICILIO';
+    estimatedDelivery = 'entre 24 a 72 horas';
+  }
+  const shippingName = orderRecord.shippingName ?? orderPayload.shippingName ?? '';
+  const shippingAddressParts = [
+    orderRecord.shippingAddress ?? orderPayload.shippingAddress ?? '',
+    orderRecord.city ?? orderPayload.city ?? '',
+    orderRecord.postalCode ?? orderPayload.postalCode ?? '',
+  ].filter(Boolean);
+  const carrierName = orderRecord.carrierName ?? '';
+  const carrierId = orderRecord.carrierId ?? '';
+  const carrierModeRaw = orderRecord.carrierMode ?? '';
+  const carrierModeNormalized = carrierModeRaw
+    ? carrierModeRaw
+        .toString()
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .trim()
+        .toUpperCase()
+    : '';
+  let carrierModeLabel = '';
+  if (
+    carrierModeNormalized === 'HOME_DELIVERY' ||
+    carrierModeNormalized === 'DELIVERY' ||
+    carrierModeNormalized === 'ENTREGA A DOMICILIO'
+  ) {
+    carrierModeLabel = 'Entrega a domicilio';
+  } else if (
+    carrierModeNormalized === 'AGENCY_PICKUP' ||
+    carrierModeNormalized === 'PICKUP' ||
+    carrierModeNormalized === 'RETIRO EN AGENCIA' ||
+    carrierModeNormalized === 'AGENCIA'
+  ) {
+    carrierModeLabel = 'Retiro en agencia';
+  }
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-sky-50 dark:from-slate-900 dark:to-slate-950">
       <Navbar />
@@ -203,6 +258,46 @@ export default function TrackOrderDetailsPage() {
                 {lastUpdate}
               </p>
             </div>
+          </CardContent>
+        </Card>
+
+        <Card className="border-blue-100 dark:border-blue-700 shadow-sm pt-0 mb-6">
+          <CardHeader className="bg-blue-50 dark:bg-blue-900 border-b border-blue-100 dark:border-blue-700 rounded-t-lg p-4">
+            <CardTitle className="text-blue-900 dark:text-blue-100">Detalles de Envío</CardTitle>
+          </CardHeader>
+          <CardContent className="p-6 grid gap-4 sm:grid-cols-2">
+            <div>
+              <p className="text-sm font-medium text-slate-500 dark:text-slate-400">Destinatario</p>
+              <p className="font-semibold text-slate-700 dark:text-slate-300">{shippingName || '—'}</p>
+            </div>
+            <div>
+              <p className="text-sm font-medium text-slate-500 dark:text-slate-400">Método de Envío</p>
+              <p className="font-semibold text-slate-700 dark:text-slate-300">{shippingMethodLabel}</p>
+            </div>
+            <div className="sm:col-span-2">
+              <p className="text-sm font-medium text-slate-500 dark:text-slate-400">Dirección</p>
+              <p className="text-slate-700 dark:text-slate-300">
+                {shippingAddressParts.length > 0 ? shippingAddressParts.join(', ') : '—'}
+              </p>
+            </div>
+            <div>
+              <p className="text-sm font-medium text-slate-500 dark:text-slate-400">Entrega Estimada</p>
+              <p className="font-semibold text-sky-600 dark:text-sky-400">{estimatedDelivery}</p>
+            </div>
+            {(carrierName || carrierModeLabel) && (
+              <div>
+                <p className="text-sm font-medium text-slate-500 dark:text-slate-400">Transportista</p>
+                <p className="font-semibold text-slate-700 dark:text-slate-300">
+                  {carrierName || '—'}
+                  {carrierId && carrierName && (
+                    <span className="ml-2 text-xs font-normal text-slate-500 dark:text-slate-400">ID: {carrierId}</span>
+                  )}
+                </p>
+                {carrierModeLabel && (
+                  <p className="text-sm text-slate-600 dark:text-slate-400 mt-1">{carrierModeLabel}</p>
+                )}
+              </div>
+            )}
           </CardContent>
         </Card>
 


### PR DESCRIPTION
## Summary
- add carrier metadata columns to orders and generate the corresponding migration
- require carrier details when completing delivery orders via a new DTO and service updates
- capture and surface carrier information across the admin/order tracking flows and API client

## Testing
- npm run lint *(fails: existing lint violations throughout backend codebase)*
- npm run lint *(fails: existing lint violations across frontend workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68cb3adfcc488323ae3f8a4b76d75bb8